### PR TITLE
Add Dynamic Member Look Up

### DIFF
--- a/Sources/SwErl/SwErl.swift
+++ b/Sources/SwErl/SwErl.swift
@@ -158,11 +158,20 @@ struct SwErlProcess {
 }
 
 /// <#Description#>
+@dynamicMemberLookup
 struct Registrar {
     var processesRegisteredByPid: [Pid:SwErlProcess] = [:]
     var processesRegisteredByName: [String:Pid] = [:]
     
     static var instance: Registrar = Registrar()
+    
+    /// Looks up a PID by its name
+    subscript(dynamicMember name: String) -> Pid {
+        guard let pid = processesRegisteredByName[name] else {
+            fatalError("PID by name: \(name) does not exist")
+        }
+        return pid
+    }
     
     /// <#Description#>
     static func register(_ toBeAdded:SwErlProcess, PID: Pid) throws {

--- a/Sources/SwErl/SwErl.swift
+++ b/Sources/SwErl/SwErl.swift
@@ -7,19 +7,19 @@
 
 import Foundation
 
-
-
 /// <#Description#>
 public enum SwErlError: Error {
-    case processAlreadyRegistered//there is a process currently registered with that name
+    /// there is a process currently registered with that name
+    case processAlreadyRegistered
 }
 
+/// <#Description#>
 struct ProcessIDCounter {
     private var queue = DispatchQueue(label: "process.counter")
     var value: UInt32 = 0
     var creation: UInt32 = 0
-
-    mutating func next()->(UInt32,UInt32) {
+    
+    mutating func next() -> (UInt32, UInt32) {
         queue.sync {
             value = value + 1
             if value == UInt32.max{
@@ -27,24 +27,30 @@ struct ProcessIDCounter {
                 creation = creation + 1
             }
         }
-        return (value,creation)
+        return (value, creation)
     }
 }
 
+/// <#Description#>
 var pidCounter = ProcessIDCounter()
 
-public struct Pid:Hashable,Equatable {
-    let id:UInt32
-    let serial:UInt32
-    let creation:UInt32
+/// <#Description#>
+public struct Pid: Hashable, Equatable {
+    /// <#Description#>
+    let id: UInt32
+    /// <#Description#>
+    let serial: UInt32
+    /// <#Description#>
+    let creation: UInt32
 }
 //typealias Pid = (id:UInt32,serial:UInt32,creation:UInt32)
 
-
-
-public func spawn(queueToUse:DispatchQueue = DispatchQueue.global(),name:String?=nil,function:@escaping @Sendable(Pid,Any)->Void)throws -> Pid {
-    let (aSerial,aCreation) = pidCounter.next()
-    let PID = Pid(id: 0,serial: aSerial,creation: aCreation)
+/// <#Description#>
+public func spawn(queueToUse: DispatchQueue = DispatchQueue.global(),
+                  name: String? = nil,
+                  function: @escaping @Sendable(Pid, Any) -> Void) throws -> Pid {
+    let (aSerial, aCreation) = pidCounter.next()
+    let PID = Pid(id: 0, serial: aSerial, creation: aCreation)
     guard let name = name else{
         try Registrar.register(SwErlProcess(registrationID: PID, functionality: function), PID: PID)
         return PID
@@ -54,9 +60,12 @@ public func spawn(queueToUse:DispatchQueue = DispatchQueue.global(),name:String?
 }
 //spawn a process with an initial state.
 //The state can be any valid Swift type, a tuple, a list, a dictionary, etc.
-///
-///The function or lambda passed will be run on a DispatchQueue. The default value is the global dispactch queue with a quality of service of .default.
-public func spawn(queueToUse:DispatchQueue = DispatchQueue.global(),name:String?=nil,initialState:Any,function:@escaping @Sendable(Pid,Any,Any)-> Any)throws -> Pid {
+
+/// The function or lambda passed will be run on a DispatchQueue. The default value is the global dispatch queue with a quality of service of .default.
+public func spawn(queueToUse: DispatchQueue = DispatchQueue.global(),
+                  name: String? = nil,
+                  initialState: Any,
+                  function: @escaping @Sendable(Pid, Any, Any) -> Any) throws -> Pid {
     let (aSerial,aCreation) = pidCounter.next()
     let PID = Pid(id: 0, serial: aSerial, creation: aCreation)
     guard let name = name else{
@@ -68,30 +77,31 @@ public func spawn(queueToUse:DispatchQueue = DispatchQueue.global(),name:String?
 }
 
 
-//If a stateful process has nil as it's state, the stateful
-//lambda will be passed an empty tuple as the state to use.
+// If a stateful process has nil as it's state, the stateful
+// lambda will be passed an empty tuple as the state to use.
 infix operator ! : ComparisonPrecedence
-extension Pid{
-    public static func !( lhs: Pid, rhs: Any) {
-        guard var process = Registrar.getProcess(forID: lhs) else{
+extension Pid {
+    /// <#Description#>
+    public static func !(lhs: Pid, rhs: Any) {
+        guard var process = Registrar.getProcess(forID: lhs) else {
             return
         }
         if let statefulClosure = process.statefulLambda{
-            do{
-                process.state = try process.queue.sync(execute:{()throws->Any in
-                    return statefulClosure(lhs,process.state!,rhs)
-                })
+            do {
+                process.state = try process.queue.sync { () throws -> Any in
+                    statefulClosure(lhs, process.state!, rhs)
+                }
                 Registrar.instance.processesRegisteredByPid[lhs] = process
             }
-            catch{
+            catch {
                 print("PID \(process.registeredPid) threw an error. SwErl processes are to deal with any throws that happen within themselves.")
             }
-        
+            
         }
-        else{
+        else {
             if let statelessClosure = process.statelessLambda{
                 process.queue.async {
-                    statelessClosure(process.registeredPid,rhs)
+                    statelessClosure(process.registeredPid, rhs)
                     
                 }
             }
@@ -99,10 +109,10 @@ extension Pid{
     }
 }
 
-//this is a facade function that uses the pid-based function
-extension String{
-    public static func !( lhs: String, rhs: Any) {
-        guard let pid = Registrar.getPid(forName: lhs) else{
+extension String {
+    /// this is a facade function that uses the pid-based function
+    public static func !(lhs: String, rhs: Any) {
+        guard let pid = Registrar.getPid(forName: lhs) else {
             return
         }
         pid ! rhs
@@ -110,34 +120,36 @@ extension String{
 }
 
 
-struct SwErlProcess{
+struct SwErlProcess {
+    /// <#Description#>
     var queue: DispatchQueue
     
-    ///
-    ///this lambda has three parameters, self(the process' registered name), state and message.
-    ///
-    var statefulLambda:((Pid, Any,Any)->Any)? = nil
-    ///
-    ///this lambda has two parameters. The first is the registered
-    ///name, self, and the second is the message
-    var statelessLambda:((Pid, Any)->Void)? = nil
-    var state:Any?
-    let registeredPid:Pid
+    /// this lambda has three parameters, self(the process' registered name), state and message.
+    var statefulLambda: ((Pid, Any, Any) -> Any)? = nil
+
+    /// this lambda has two parameters. The first is the registered
+    /// name, self, and the second is the message
+    var statelessLambda: ((Pid, Any) -> Void)? = nil
+    var state: Any?
+    let registeredPid: Pid
     
+    
+    /// <#Description#>
+    /// - Parameter functionality: the returned value is used as the next state.
     init(queueToUse:DispatchQueue = statefulProcessDispatchQueue,
-         registrationID:Pid,
-         initialState:Any,
-         functionality: @escaping @Sendable (Pid,Any,Any) -> Any) throws {//the returned value is used as the next state.
+         registrationID: Pid,
+         initialState: Any,
+         functionality: @escaping @Sendable (Pid, Any, Any) -> Any) throws {
         self.queue = queueToUse
         self.statefulLambda = functionality
         self.state = initialState
         self.registeredPid = registrationID
-        
     }
     
-    init(queueToUse:DispatchQueue = DispatchQueue.global(),
-         registrationID:Pid,
-         functionality: @escaping @Sendable (Pid,Any) -> Void ) throws{
+    /// <#Description#>
+    init(queueToUse: DispatchQueue = DispatchQueue.global(),
+         registrationID: Pid,
+         functionality: @escaping @Sendable (Pid,Any) -> Void ) throws {
         self.queue = queueToUse
         self.statelessLambda = functionality
         self.state = nil
@@ -145,51 +157,68 @@ struct SwErlProcess{
     }
 }
 
-struct Registrar{
-    static var instance:Registrar = Registrar()
-    var processesRegisteredByPid:[Pid:SwErlProcess] = [:]
-    var processesRegisteredByName:[String:Pid] = [:]
-    static func register(_ toBeAdded:SwErlProcess, PID:Pid)throws{
-        guard Registrar.getProcess(forID: PID) == nil else{
+/// <#Description#>
+struct Registrar {
+    var processesRegisteredByPid: [Pid:SwErlProcess] = [:]
+    var processesRegisteredByName: [String:Pid] = [:]
+    
+    static var instance: Registrar = Registrar()
+    
+    /// <#Description#>
+    static func register(_ toBeAdded:SwErlProcess, PID: Pid) throws {
+        guard Registrar.getProcess(forID: PID) == nil else {
             throw SwErlError.processAlreadyRegistered
         }
         instance.processesRegisteredByPid.updateValue(toBeAdded, forKey: PID)
     }
-    static func register(_ toBeAdded:SwErlProcess, name:String, PID:Pid)throws{
-        guard Registrar.getProcess(forID: name) == nil else{
+    
+    /// <#Description#>
+    static func register(_ toBeAdded: SwErlProcess, name: String, PID: Pid) throws {
+        guard Registrar.getProcess(forID: name) == nil else {
             throw SwErlError.processAlreadyRegistered
         }
         instance.processesRegisteredByPid.updateValue(toBeAdded, forKey: PID)
         instance.processesRegisteredByName.updateValue(PID, forKey: name)
     }
     
-    static func remove(_ registrationID:Pid){
+    /// <#Description#>
+    static func remove(_ registrationID: Pid){
         instance.processesRegisteredByPid.removeValue(forKey: registrationID)
     }
-    static func getProcess(forID:Pid)->SwErlProcess?{
-        return instance.processesRegisteredByPid[forID]
+    
+    /// <#Description#>
+    static func getProcess(forID: Pid) -> SwErlProcess? {
+        instance.processesRegisteredByPid[forID]
     }
-    static func getProcess(forID:String)->SwErlProcess?{
-        guard let pid =  instance.processesRegisteredByName[forID] else { return nil
+    
+    /// <#Description#>
+    static func getProcess(forID: String) -> SwErlProcess? {
+        guard let pid = instance.processesRegisteredByName[forID] else {
+            return nil
         }
         return instance.processesRegisteredByPid[pid]
     }
-    static func getPid(forName:String)->Pid?{
-        return instance.processesRegisteredByName[forName]
+    
+    /// <#Description#>
+    static func getPid(forName: String) -> Pid? {
+        instance.processesRegisteredByName[forName]
     }
-    static func getAllPIDs()->Dictionary<Pid, SwErlProcess>.Keys{
-        return instance.processesRegisteredByPid.keys
+    
+    /// <#Description#>
+    static func getAllPIDs() -> Dictionary<Pid, SwErlProcess>.Keys {
+        instance.processesRegisteredByPid.keys
     }
-    static func getAllNames()->Dictionary<String, Pid>.Keys{
-        return instance.processesRegisteredByName.keys
+    
+    /// <#Description#>
+    static func getAllNames() -> Dictionary<String, Pid>.Keys {
+        instance.processesRegisteredByName.keys
     }
 }
 
 ///
-///here is the single instance of Registrar that should be created.
+/// here is the single instance of Registrar that should be created.
 ///
 
-
-
-public let statefulProcessDispatchQueue = DispatchQueue(label: "statefulDispatchQueue",qos: .default)
+/// <#Description#>
+public let statefulProcessDispatchQueue = DispatchQueue(label: "statefulDispatchQueue", qos: .default)
 

--- a/Tests/SwErlTests/SwErlTests.swift
+++ b/Tests/SwErlTests/SwErlTests.swift
@@ -59,8 +59,8 @@ final class SwErlTests: XCTestCase {
             return
         }
     
-//        XCTAssertEqual(Registrar.instance.silly.serial, 1)
-//        XCTAssertEqual(Registrar.instance.silly.creation, 0)
+        XCTAssertEqual(Registrar.instance.silly.serial, 1)
+        XCTAssertEqual(Registrar.instance.silly.creation, 0)
         XCTAssertEqual(1, Registrar.instance.processesRegisteredByName.count)
     }
     
@@ -70,7 +70,7 @@ final class SwErlTests: XCTestCase {
             expectation.fulfill()
             return
         }
-//        Registrar.instance.silly ! 5
+        Registrar.instance.silly ! 5
         "silly" ! 5
         wait(for: [expectation], timeout: 10.0)
     }


### PR DESCRIPTION
# The Changes
## Apply Swift Lint
This added spacing to aid in readability....  
I've also added comments to help describe the public functions and their intentions to consumers.

## Dynamic Look Up
This will allow you to look up any registered PID by using the name of the PID.  
It is done by adding property to the Registrar's instance which is the name of the PID.

```swift
_ = try spawn(name:"silly"){(PID, message) in
    print("hello \(message)")
    return
}

// access the PID "silly" via property instead of a string name
Registrar.instance.silly
```