### PR TITLE
Reintroduce concurrency

### DIFF
--- a/Sources/SwErl/SwErl.swift
+++ b/Sources/SwErl/SwErl.swift
@@ -72,7 +72,7 @@ public typealias SwErlStatelessHandler = (Pid, SwErlMessage) -> ()
 ///   - `.alreadyStarted`: Indicates an attempt to start a process that has already been started.
 ///
 /// - Author: Lee S. Barney
-/// - Version: 0.1 
+/// - Version: 0.1
 // MARK: SwErlError
 public enum SwErlError: Error {
     case processAlreadyLinked
@@ -447,43 +447,41 @@ public enum SwErlPassed{
     Registrar.setProcessState(forID: PID, value: initialState)
     return PID
 }
-/**
- This function is used to link a unique name to a stateful function or closure that is executed asynchronously with no result being sent to the process sending the message. Any DispatchQueue desired for running the function or closure can be passed as the first parameter. The state can be any valid Swift type, a tuple, a list, a dictionary, optional, closure, etc.
- - Parameters:
- - makeAvailable: options:Availability.local or Availability.global. The .global option allows other nodes to execute the function or closure on the node it is spawned inside of.
- - queueToUse: any DispatchQueue, custom or built-in. Default is _DispatchQueue.global()_
- - name: a unique string optional used as an identifier. . Default is nil_
- - function: the function or closure to execute using the DispatchQueue
- - Value: a SwErl Pid
- - Author:
- Lee S. Barney
- - Version:
- 0.1
- */
+/// Links a unique name to a stateful function or closure, executing it asynchronously without sending a result back to the message sender. The execution queue can be any `DispatchQueue`, either custom or built-in, with a default of `DispatchQueue.global()`. The state managed by this function or closure can be of any valid Swift type, facilitating flexible and dynamic state management strategies.
+///
+/// - Parameters:
+///   - makeAvailable: Determines the availability scope of the function or closure, with options being `.local` or `.global`. The `.global` option allows the function or closure to be executed by other nodes within the node it is spawned.
+///   - queueToUse: The `DispatchQueue` on which the function or closure will be executed. Defaults to `DispatchQueue.global()`.
+///   - name: An optional unique string identifier for the function or closure. Defaults to `nil`.
+///   - function: The function or closure to be executed asynchronously on the specified `DispatchQueue`.
+/// - Returns: A SwErl `Pid` that uniquely identifies the spawned process.
+///
+/// - Author: Lee S. Barney
+/// - Version: 0.1
+
 @discardableResult public func spawnasysf(queueToUse:DispatchQueue = DispatchQueue.global(),name:String?=nil,initialState:SwErlState,function:@escaping @Sendable(Pid,SwErlState,SwErlMessage)->SwErlState)throws -> Pid {
     let PID = Registrar.generatePid()
     guard let name = name else{
         try Registrar.link(SwErlProcess(queueToUse:queueToUse, registrationID: PID, functionality: function), PID: PID)
-        Registrar.setProcessState(forID: PID, value: initialState)
+        Registrar.local.processStates[PID] = initialState
         return PID
     }
     try Registrar.link(SwErlProcess(queueToUse:queueToUse, registrationID: PID, functionality: function), name: name, PID: PID)
-    Registrar.setProcessState(forID: PID, value: initialState)
+    Registrar.local.processStates[PID] = initialState
     return PID
 }
 
-/**
- This function is used to link a unique name to a stateless function or closure that is executed asynchronously. The function is then available to be called remotely from any SwErl compatable node. Any DispatchQueue desired for running the function or closure can be passed as the first parameter.
- - Parameters:
- - queueToUse: any DispatchQueue, custom or built-in. Default is _DispatchQueue.global()_
- - name: a unique string used as an identifier.
- - function: the function or closure to execute using the DispatchQueue
- - Value: a SwErl Pid
- - Author:
- Lee S. Barney
- - Version:
- 0.1
- */
+/// Links a unique name to a stateless function or closure, executing it asynchronously. Once linked, the function becomes available for remote calls from any SwErl compatible node. This setup supports using any desired `DispatchQueue` for execution, facilitating integration with both custom and built-in dispatch queues.
+///
+/// - Parameters:
+///   - queueToUse: The `DispatchQueue` on which the function or closure will be executed. Defaults to `DispatchQueue.global()`.
+///   - name: A unique string identifier for the function or closure.
+///   - function: The function or closure to be executed asynchronously on the specified `DispatchQueue`.
+/// - Returns: A SwErl `Pid` that uniquely identifies the linked function or closure.
+///
+/// - Author: Lee S. Barney
+/// - Version: 0.1
+
 // MARK: Spawn Globally
 @discardableResult public func spawnGlobally(queueToUse:DispatchQueue = DispatchQueue.global(),name:String,function:@escaping @Sendable(Pid,SwErlMessage)->Void)throws -> Pid {
     let PID = Registrar.generatePid()
@@ -491,22 +489,21 @@ public enum SwErlPassed{
     return PID
 }
 
-/**
- This function is used to link a unique name to a stateful function or closure that is executed synchronously. The function is then available to be called remotely from any SwErl compatable node. A result is sent back to the process sending the initial message. Any DispatchQueue desired for running the function or closure can be passed as the first parameter. The state can be any valid Swift type, a tuple, a list, a dictionary, optional, closure, etc.
- - Parameters:
- - queueToUse: any DispatchQueue, custom or built-in.. Default is _DispatchQueue.global()_
- - name: a unique string used as an identifier.
- - function: the function or closure to execute using the DispatchQueue
- - Value: a SwErl Pid
- - Author:
- Lee S. Barney
- - Version:
- 0.1
- */
+/// Links a unique name to a stateful function or closure, executing it synchronously. This function becomes available for remote invocation from any SwErl compatible node, with results being sent back to the initiating process. The execution context can be specified through any `DispatchQueue`, allowing for flexibility in where and how the function or closure runs. The state managed by this function or closure can encompass any valid Swift type, enabling a wide range of data structures and logic encapsulations.
+///
+/// - Parameters:
+///   - queueToUse: The `DispatchQueue` for executing the function or closure. Defaults to `DispatchQueue.global()`.
+///   - name: A unique string identifier for the function or closure.
+///   - function: The function or closure to be executed synchronously on the specified `DispatchQueue`.
+/// - Returns: A SwErl `Pid` that uniquely identifies the linked function or closure.
+///
+/// - Author: Lee S. Barney
+/// - Version: 0.1
+
 @discardableResult public func spawnGlobally(queueToUse:DispatchQueue = DispatchQueue.global(),name:String,initialState:SwErlState,function:@escaping @Sendable(Pid,SwErlState,SwErlMessage) -> (SwErlResponse,SwErlState))throws -> Pid {
     let PID = Registrar.generatePid()
     try Registrar.link(SwErlProcess(registrationID: PID, functionality: function), .global, name: name, PID: PID)
-    Registrar.setProcessState(forID: PID, value: initialState)
+    Registrar.local.processStates[PID] = initialState
     return PID
 }
 
@@ -817,7 +814,7 @@ struct Registrar{
     ///
     /// - Complexity: O(1) constant time.
     static func generatePid()->Pid{
-        queue.sync{
+        queue.sync(flags: .barrier){
             let (anID,aSerial) = pidCounter.next()
             return Pid(id: anID, serial: aSerial, creation: 0)
         }
@@ -837,7 +834,7 @@ struct Registrar{
     /// - Complexity: O(1) constant time for local or global link.
     // MARK: Registrar Link
     static func link(_ toBeAdded:SwErlProcess,_ makeAvailable:RegistrationType = RegistrationType.local, initState:Any = "SwErlNone", name:String = "SwErlNone", PID:Pid) throws{
-        try queue.sync {
+        try queue.sync(flags: .barrier) {
             //This implementation has a lot of code duplication in it.
             //The implementation where a local variable is used to hold
             //the registrar instance to use, local or global,
@@ -896,7 +893,7 @@ struct Registrar{
     /// - Complexity: O(1) constant time for local or global link.
     
     static func link<T:OTPActor_behavior>(callbackType: T.Type,_ makeAvailable:RegistrationType = RegistrationType.local, processQueue: DispatchQueue, initState: Any?, name:String = "SwErlNone", PID:Pid) throws{
-        try queue.sync {
+        try queue.sync(flags: .barrier) {
             //This implementation has a lot of code duplication in it.
             //The implementation where a local variable is used to hold
             //the registrar instance to use, local or global,
@@ -935,8 +932,8 @@ struct Registrar{
     /// - Complexity: O(1) constant time.
     // MARK: Registrar Unlink
     static func unlink(_ registrationID:Pid){
-        _ = queue.sync { local.processesLinkedToPid.removeValue(forKey: registrationID) }
-        _ = queue.sync { local.OTPActorsLinkedToPid.removeValue(forKey: registrationID) }
+        _ = queue.sync(flags: .barrier) { local.processesLinkedToPid.removeValue(forKey: registrationID) }
+        _ = queue.sync(flags: .barrier) { local.OTPActorsLinkedToPid.removeValue(forKey: registrationID) }
     }
     
     /// Removes the link between a name and a `Pid`, and removes the associated process.
@@ -946,10 +943,10 @@ struct Registrar{
     ///
     /// - Complexity: O(1) constant time.
     static func unlink(_ name:String){
-        guard let PID = Registrar.getPid(forName: name) else{
+        guard let PID = queue.sync(execute: {local.processesLinkedToName[name]}) else{
             return
         }
-        _ = queue.sync{ local.processesLinkedToName.removeValue(forKey: name) }
+        _ = queue.sync(flags: .barrier){ local.processesLinkedToName.removeValue(forKey: name) }
         Registrar.unlink(PID)
     }
     
@@ -1002,7 +999,7 @@ struct Registrar{
     
     /// - Complexity: O(1) constant time.
     static func getProcess(forID:String)->SwErlProcess?{
-        guard let pid = queue.sync(flags: .barrier, execute: {local.processesLinkedToName[forID]}) else {
+        guard let pid = queue.sync(execute: {local.processesLinkedToName[forID]}) else {
             return nil
         }
         return getProcess(forID: pid)

--- a/Tests/SwErlGenServerTests/StopTests.swift
+++ b/Tests/SwErlGenServerTests/StopTests.swift
@@ -49,25 +49,16 @@ final class RequestAfterShutdown: XCTestCase {
     override func tearDown() {
         resetRegistryAndPIDCounter()
     }
-    //
-    //testRequestAfterShutdown needs to be reworked.
-    //
-//    func testRequestAfterShutdown() {
-//        // make sure each cast takes place in order
-//        let Q = DispatchQueue(label: "temp q to ensure things are added in order")
-//        
-//        Q.sync { try! GenServer.cast("queue server", "delay") }
-//        _ = Q.sync { GenServer.unlink("queue server", "shutdown") }
-//
-//        Q.sync { try! GenServer.cast("queue server", "fulfill") }//error not expected here
-//        wait(for: [noRun], timeout: 4) //inverted expectation
-//    }
-}
+    
+    func testRequestAfterShutdown() {
+        // make sure each cast takes place in order
+        let Q = DispatchQueue(label: "temp q to ensure things are added in order")
+        
+        Q.sync { try! GenServer.cast("queue server", "delay") }
+        _ = Q.sync { GenServer.unlink("queue server", "shutdown") }
 
-final class SpeedAndSizeTests:XCTestCase {
-    func testGenserverSize() throws{
-        print("\n\n\n!!!!!!!!!!!!!!!!!!! \nsize of registered genServer process instances' size: \(MemoryLayout<SwErlProcess>.size + MemoryLayout<DispatchQueue>.size + MemoryLayout<GenServerBehavior>.size) bytes")
-        print("!!!!!!!!!!!!!!!!!!!")
+        Q.sync { try! GenServer.cast("queue server", "fulfill") }//error not expected here
+        wait(for: [noRun], timeout: 4) //inverted expectation
     }
 }
 

--- a/Tests/SwErlStatemTests/GenStatemConcurrencyTests.swift
+++ b/Tests/SwErlStatemTests/GenStatemConcurrencyTests.swift
@@ -86,7 +86,7 @@ final class GenStatemConcurrencyTests: XCTestCase {
     func testConcurrentCall()throws{
         try GenStateM.startLink(name: "called_to", statem: expectationStateM.self, initialData: 3)
         let testQueue = DispatchQueue(label: "testCQ", attributes: .concurrent)
-        let count = 10000
+        let count = 100000
         var expectations:[XCTestExpectation] = []
         for i in 1...count {
             let callExpectation = XCTestExpectation(description: "call\(i)")
@@ -95,13 +95,13 @@ final class GenStatemConcurrencyTests: XCTestCase {
                 _ = GenStateM.call(name: "called_to",message: callExpectation)
             }
         }
-        wait(for: expectations, timeout: 5.0)
+        wait(for: expectations, timeout: 20.0)
     }
     
     func testConcurrentCast()throws{
         try GenStateM.startLink(name: "cast_to", statem: expectationStateM.self, initialData: 3)
         let testQueue = DispatchQueue(label: "testCQ", attributes: .concurrent)
-        let count = 10000
+        let count = 100000
         var expectations:[XCTestExpectation] = []
         for i in 1...count {
             let callExpectation = XCTestExpectation(description: "cast\(i)")
@@ -110,13 +110,13 @@ final class GenStatemConcurrencyTests: XCTestCase {
                 GenStateM.cast(name: "cast_to",message: callExpectation)
             }
         }
-        wait(for: expectations, timeout: 10.0)
+        wait(for: expectations, timeout: 20.0)
     }
     
     func testConcurrentNotify()throws{
         try GenStateM.startLink(name: "notice_receiver", statem: expectationStateM.self, initialData: 3)
         let testQueue = DispatchQueue(label: "testCQ", attributes: .concurrent)
-        let count = 10000
+        let count = 100000
         var expectations:[XCTestExpectation] = []
         for i in 1...count {
             let noticeExpectation = XCTestExpectation(description: "notice\(i)")
@@ -125,7 +125,7 @@ final class GenStatemConcurrencyTests: XCTestCase {
                 GenStateM.notify(name: "notice_receiver",message: noticeExpectation)
             }
         }
-        wait(for: expectations, timeout: 5.0)
+        wait(for: expectations, timeout: 20.0)
     }
 
 }

--- a/Tests/SwErlTests/SwErlSpeedTests.swift
+++ b/Tests/SwErlTests/SwErlSpeedTests.swift
@@ -60,7 +60,7 @@ final class SwErlSpeedTests: XCTestCase {
         
         let timer = ContinuousClock()
         var totalTime:Int64 = 0
-        let count:Int64 = 100000
+        let count:Int64 = 1000000
         for _ in 0..<count{
             let time = try timer.measure{
                 _ = try spawnasysf(initialState: 7, function: asyncStateful)


### PR DESCRIPTION
Adds .barrier flags back in where appropriate, removed extraneous queue references, removed concurrency bug from the bang operator.