### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![SwErl](Sources/SwErl/SwErl.docc/resources/logo_text.svg)
-SwErl is a general purpose concurrency library conforming to the design patterns and principles found in the Erlang Programming Language. SwErl also includes SwErl Node, an as-of-yet incomplete library allowing native Swift to connect to a distributed Erlang system as a near-fully featured node. For Swift Developers with little to no Erlang experience, a quick primer for SwErl [is provided here.](Sources/SwErl/SwErl/docc/BasicUsage.md) 
+SwErl is a general purpose concurrency library conforming to the design patterns and principles found in the Erlang Programming Language. SwErl also includes SwErl Node, an as-of-yet incomplete library allowing native Swift to connect to a distributed Erlang system as a near-fully featured node. For Swift Developers with little to no Erlang experience, a quick primer for SwErl [is provided here](Sources/SwErl/SwErl.docc/GettingStarted.md).
 ## Why SwErl?
 
 ### Painless Concurrency


### PR DESCRIPTION
* the Erlang primer mentioned in README [no more exists](https://github.com/inter-erlang/SwErl/blob/main/Sources/SwErl/SwErl/docc/BasicUsage.md)
* replaced the link with [GettingStarted.md](https://github.com/inter-erlang/SwErl/blob/94ff25260e46b08260b5063d2e2efc892bbafb71/Sources/SwErl/SwErl.docc/GettingStarted.md).