### PR TITLE
Year bump in copyrights

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Lee Barney
+Copyright (c) 2024 Lee Barney
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/EventManager.swift
+++ b/Sources/SwErl/EventManager.swift
@@ -2,7 +2,7 @@
 //  events.swift
 //
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/GenServer.swift
+++ b/Sources/SwErl/GenServer.swift
@@ -1,7 +1,7 @@
 //
 //  GenServer.swift
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/GenStateM.swift
+++ b/Sources/SwErl/GenStateM.swift
@@ -1,7 +1,7 @@
 //
 //  GenStateM.swift
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/OTP_base.swift
+++ b/Sources/SwErl/OTP_base.swift
@@ -1,7 +1,7 @@
 //
 //  OTP_base.swift
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/SafeDataStructures.swift
+++ b/Sources/SwErl/SafeDataStructures.swift
@@ -1,7 +1,7 @@
 //
 //  SafeDataStructures.swift
 //  
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Sources/SwErl/SwErl.swift
+++ b/Sources/SwErl/SwErl.swift
@@ -3,7 +3,7 @@
 //
 //MIT License
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal

--- a/Tests/SwErlTests/SwErlTests.swift
+++ b/Tests/SwErlTests/SwErlTests.swift
@@ -1,7 +1,7 @@
 //
 //  SwErlTests.swift
 //
-//Copyright (c) 2023 Lee Barney
+//Copyright (c) 2024 Lee Barney
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
```shell
git grep -P '\d{4}\sLee' | \
        awk -F: '{print $1}' | \
        xargs -I {} sh -c 'year=`date +"%Y"`; sed -i -ne "s/[[:digit:]]\{4\}\( Lee\)/${year}\1/;p" {}'
```